### PR TITLE
chore: log executed queries on failure

### DIFF
--- a/connection/client.lisp
+++ b/connection/client.lisp
@@ -53,9 +53,13 @@ When SEND-TO-SINGLE is truethy and multple endpoints are available, the request 
                      (setf result body))
                  (FAST-HTTP.ERROR:CB-MESSAGE-COMPLETE (e)
                    (format t "~&Encountered error from FAST-HTTP: ~A" e)
+                   (when *log-sparql-query-roundtrip*
+                     (format t "~&Logging query that led to failure:~%~A" string))
                    (support:report-exponential-backoff-failure e))
                  (error (e)
                    (format t "~&Encountered general error when executing query: ~A" e)
+                   (when *log-sparql-query-roundtrip*
+                     (format t "~&Logging query that led to failure:~%~A" string))
                    (support:report-exponential-backoff-failure e)))))
     result))
 


### PR DESCRIPTION
This logging is conditional on the same `*log-sparql-query-roundtrip*` variable. The idea is that when someone is interested in in- and outbound logs of a SPARQL query, they're probably also interested in those logs if the query fails. If this ends up being too chatty, it can be moved behind a separate variable.