### PR TITLE
fix: reverse the PREFIXes when adding a BASE to the prologue

### DIFF
--- a/sparql-ast/manipulation.lisp
+++ b/sparql-ast/manipulation.lisp
@@ -478,7 +478,7 @@ destructured bindings of LAMBDA-LIST as per DESTRUCTURING-BIND."
     (ebnf::|Prologue|
            (setf (sparql-parser:match-submatches match)
                  (cons (mk-match `(ebnf::|BaseDecl| "BASE" ,(iriref base-uri)))
-                       (reverse (sparql-parser:match-submatches match))))
+                       (sparql-parser:match-submatches match)))
            match)))
 
 (defun replace-iriref (sparql-ast &key from to)

--- a/sparql-ast/manipulation.lisp
+++ b/sparql-ast/manipulation.lisp
@@ -478,7 +478,7 @@ destructured bindings of LAMBDA-LIST as per DESTRUCTURING-BIND."
     (ebnf::|Prologue|
            (setf (sparql-parser:match-submatches match)
                  (cons (mk-match `(ebnf::|BaseDecl| "BASE" ,(iriref base-uri)))
-                       (sparql-parser:match-submatches match)))
+                       (reverse (sparql-parser:match-submatches match))))
            match)))
 
 (defun replace-iriref (sparql-ast &key from to)

--- a/updates/detect-quads.lisp
+++ b/updates/detect-quads.lisp
@@ -78,7 +78,11 @@
                                    (alexandria:appendf
                                     (info-operations *info*)
                                     `((:modify (:delete-patterns ,(info-quads *info*)
-                                                :query ,(make-select-query-for-patterns quad-pattern (info-prefixes *info*) (info-base *info*) (info-quads *info*)))))))))
+                                                :query ,(make-select-query-for-patterns
+                                                         quad-pattern
+                                                         (reverse (info-prefixes *info*))
+                                                         (info-base *info*)
+                                                         (info-quads *info*)))))))))
 (handle ebnf::|DeleteData|
         :local-context (:quads nil)
         :process (ebnf::|QuadData|)
@@ -250,7 +254,7 @@ detect-quads-processing-handlers::|VarOrTerm|."
                   (let ((modify `((:modify (:delete-patterns ,delete-patterns
                                             :insert-patterns ,insert-patterns
                                             :query ,(make-select-query-for-patterns expanded-group-graph-pattern
-                                                                                    (info-prefixes *info*)
+                                                                                    (reverse (info-prefixes *info*))
                                                                                     (info-base *info*)
                                                                                     insert-patterns
                                                                                     delete-patterns))))))


### PR DESCRIPTION
The AST of the SPARQL query stores the prefixes in reverse order for some reason. This isn't necessarily the right place to fix this, but it's an easy spot to reverse the reversal and ensure that the prefixes are following the same order that the user supplied them in.

The order of the prefixes is important because if two prefixes are defined, the latter "wins" and shadows the former. As of writing, the JS template automatically adds some prefixes, one of which is mu with an unexpected URI expansion. Without this fix, this ends up breaking queries that depend on the mu prefix.

A concrete example, the following query:

```sparql
PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

PREFIX muExt: <http://mu.semte.ch/vocabularies/ext/>
PREFIX muCore: <http://mu.semte.ch/vocabularies/core/>
PREFIX mu: <http://mu.semte.ch/vocabularies/>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

SELECT DISTINCT ?agendaitem ?newDocument
WHERE {
  ?newDocument mu:uuid """6634C7AFF96D38DDE006A4E7""" .
  ?agendaitem mu:uuid """f1e42414-0932-11ef-b935-71fbda946ed9""" .
}
```

Gets turned into:

```sparql
BASE <http://mu.semte.ch/prefix/local/> PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#> PREFIX mu: <http://mu.semte.ch/vocabularies/core/> PREFIX muExt: <http://mu.semte.ch/vocabularies/ext/> PREFIX muCore: <http://mu.semte.ch/vocabularies/core/> PREFIX mu: <http://mu.semte.ch/vocabularies/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT DISTINCT ?agendaitem ?newDocument FROM <http://mu.semte.ch/graphs/system/parliament> FROM <http://mu.semte.ch/graphs/system/signing> FROM <http://mu.semte.ch/graphs/system/email> FROM <http://mu.semte.ch/graphs/organizations/kanselarij> FROM <http://mu.semte.ch/graphs/system/users> FROM <http://mu.semte.ch/graphs/staatsblad> FROM <http://mu.semte.ch/graphs/sessions> FROM <http://mu.semte.ch/graphs/public> WHERE { ?newDocument mu:uuid """6634C7AFF96D38DDE006A4E7""" . ?agendaitem mu:uuid """f1e42414-0932-11ef-b935-71fbda946ed9""" . }
```

Notice that the last encountered `PREFIX mu:` is  `<http://mu.semte.ch/vocabularies/>`, which isn't the expected value.

After the fix it becomes:

```sparql
BASE <http://mu.semte.ch/prefix/local/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> PREFIX mu: <http://mu.semte.ch/vocabularies/> PREFIX muCore: <http://mu.semte.ch/vocabularies/core/> PREFIX muExt: <http://mu.semte.ch/vocabularies/ext/> PREFIX mu: <http://mu.semte.ch/vocabularies/core/> PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#> SELECT DISTINCT ?agendaitem ?newDocument FROM <http://mu.semte.ch/graphs/system/parliament> FROM <http://mu.semte.ch/graphs/system/signing> FROM <http://mu.semte.ch/graphs/system/email> FROM <http://mu.semte.ch/graphs/organizations/kanselarij> FROM <http://mu.semte.ch/graphs/system/users> FROM <http://mu.semte.ch/graphs/staatsblad> FROM <http://mu.semte.ch/graphs/sessions> FROM <http://mu.semte.ch/graphs/public> WHERE { ?newDocument mu:uuid """6634C7AFF96D38DDE006A4E7""" . ?agendaitem mu:uuid """f1e42414-0932-11ef-b935-71fbda946ed9""" . }
```